### PR TITLE
Make smaller screens happier

### DIFF
--- a/lib/pages/updateProfileImage.dart
+++ b/lib/pages/updateProfileImage.dart
@@ -78,7 +78,6 @@ class _UpdateProfileImageState extends State<UpdateProfileImage> {
                         height: 500.0,
                       ),
                     ),
-                    SizedBox(height: 80.0),
                     ButtonTheme(
                       height: 60.0,
                       minWidth: 1000.0,


### PR DESCRIPTION
Remove SizedBox so Update button appears on smaller devices. Pixel 3 isn't even small, but button was off the screen.

Perhaps if option to scroll was obvious, it would be okay. Or perhaps a save button in the upper corner of the screen.